### PR TITLE
Fix integer square root

### DIFF
--- a/resources/SquareRoot.py
+++ b/resources/SquareRoot.py
@@ -35,7 +35,7 @@ class SquareRoot(Common):
 
         start_time = time.time()
         res = self.baseTransform(
-            int(math.sqrt(int(x, self.base)))
+            math.isqrt(int(x, self.base))
         )
         time_exec.set(f'(time: {time.time() - start_time})')
 

--- a/test.py
+++ b/test.py
@@ -278,6 +278,15 @@ class MASCryptTest(unittest.TestCase):
             lsr.SquareRoot(10).integerSquareRoot(self.time_exec, a)
         )
 
+    def test_square_root_dec_float_precision_limit(self):
+        """ Test decimal square root operation in float precision limit. """
+        a = '263836759585588630746'
+        res = 16243052655 # 16243052655.99999927384339325
+        self.assertEqual(
+            res,
+            lsr.SquareRoot(10).integerSquareRoot(self.time_exec, a)
+        )
+
     def test_square_root_hex(self):
         """ Test hexadecimal square root operation. """
         a = '237147653761586237512'

--- a/test.py
+++ b/test.py
@@ -748,3 +748,6 @@ class MASCryptTest(unittest.TestCase):
                 self.time_exec, a, y, n
             )
         )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test.py
+++ b/test.py
@@ -14,12 +14,12 @@ import resources.LCM as llcm
 import resources.Primality as lp
 import resources.Factorization as lf
 import resources.DiscreteLogarithm as ldl
-from tkinter import Tk, StringVar
 
+class StringVar(): 
+    def set(self,_): pass
 
 class MASCryptTest(unittest.TestCase):
 
-    root = Tk()
     time_exec = StringVar()
 
     def test_addition_bin(self):


### PR DESCRIPTION
Hi.

There seems to be a bug in the implementation of the integer square root.

The error is caused by the "**sqrt(n)**" function of the "**math**" module, which works natively and returns a float number.

Although in Python integers have arbitrary precision, all platforms map floats according [IEEE-754 "double precision" ](https://docs.python.org/3/tutorial/floatingpoint.html) standard, which can manage around 18 decimal digits, but when a value exceeds this limit it is rounded.

Using ["decimal" module](https://docs.python.org/3/library/decimal.html), the precision can be extended up to the physical limit of the computer's memory, but this does not solve the problem.

For the integer square root case, the most optimal solution is to use the built-in implementation present since Python 3.8. in the "math" module, "**isqrt(n)**" that returns the integer square root of the nonnegative integer n. This is the floor of the exact square root of n, or equivalently, the largest integer a such that a² ≤ n.

It's easy to do a quick check:
```python
>>> from math import sqrt,isqrt
>>>
>>> n = 263836759585588630746
>>>
>>> sqrt(n)
16243052656.0
>>>
>>> isqrt(n)
16243052655
>>>
```

I've added a check to the unit tests so you can verify the solution.
Before fixing:
```
$ python3 test.py -v MASCryptTest.test_square_root_dec_float_precision_limit
test_square_root_dec_float_precision_limit (__main__.MASCryptTest)
Test decimal square root operation in float precision limit. ... FAIL

======================================================================
FAIL: test_square_root_dec_float_precision_limit (__main__.MASCryptTest)
Test decimal square root operation in float precision limit.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test.py", line 285, in test_square_root_dec_float_precision_limit
    self.assertEqual(
AssertionError: 16243052655 != 16243052656

----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (failures=1)
```

After fixing:
```
$ python3 test.py -v MASCryptTest.test_square_root_dec_float_precision_limit
test_square_root_dec_float_precision_limit (__main__.MASCryptTest)
Test decimal square root operation in float precision limit. ... ok

----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
```

I hope you find it useful.
Best regards.
Jorge Rivera.

